### PR TITLE
Fix: Enable tag removal when tags array is empty (#3)

### DIFF
--- a/server/applescript-templates.js
+++ b/server/applescript-templates.js
@@ -255,14 +255,24 @@ export class AppleScriptTemplates {
     }
     
     // Update tags if provided
-    if (tags && tags.length > 0) {
-      const tagPlaceholders = tags.map((_, index) => `"{{tag_${index}}}"`).join(", ");
-      script += `
+    if (tags !== undefined) {
+      if (tags.length > 0) {
+        const tagPlaceholders = tags.map((_, index) => `"{{tag_${index}}}"`).join(", ");
+        script += `
         try
           set tag names of targetTodo to {${tagPlaceholders}}
         on error
           -- Tags assignment failed, continue without tags
         end try`;
+      } else {
+        // Empty array means remove all tags
+        script += `
+        try
+          set tag names of targetTodo to {}
+        on error
+          -- Tags removal failed, continue
+        end try`;
+      }
     }
     
     // Move to project if provided
@@ -341,14 +351,24 @@ export class AppleScriptTemplates {
     }
     
     // Update tags if provided
-    if (tags && tags.length > 0) {
-      const tagPlaceholders = tags.map((_, index) => `"{{tag_${index}}}"`).join(", ");
-      script += `
+    if (tags !== undefined) {
+      if (tags.length > 0) {
+        const tagPlaceholders = tags.map((_, index) => `"{{tag_${index}}}"`).join(", ");
+        script += `
         try
           set tag names of targetProject to {${tagPlaceholders}}
         on error
           -- Tags assignment failed, continue without tags
         end try`;
+      } else {
+        // Empty array means remove all tags
+        script += `
+        try
+          set tag names of targetProject to {}
+        on error
+          -- Tags removal failed, continue
+        end try`;
+      }
     }
     
     // Move to area if provided

--- a/server/applescript-templates.js
+++ b/server/applescript-templates.js
@@ -255,7 +255,10 @@ export class AppleScriptTemplates {
     }
     
     // Update tags if provided
-    if (tags !== undefined) {
+    if (tags !== undefined && tags !== null) {
+      if (!Array.isArray(tags)) {
+        throw new Error('tags parameter must be an array');
+      }
       if (tags.length > 0) {
         const tagPlaceholders = tags.map((_, index) => `"{{tag_${index}}}"`).join(", ");
         script += `
@@ -351,7 +354,10 @@ export class AppleScriptTemplates {
     }
     
     // Update tags if provided
-    if (tags !== undefined) {
+    if (tags !== undefined && tags !== null) {
+      if (!Array.isArray(tags)) {
+        throw new Error('tags parameter must be an array');
+      }
       if (tags.length > 0) {
         const tagPlaceholders = tags.map((_, index) => `"{{tag_${index}}}"`).join(", ");
         script += `

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -42,7 +42,8 @@ async function main() {
     path.join(__dirname, 'validation.test.js'),
     path.join(__dirname, 'parameter-mapping.test.js'),
     path.join(__dirname, 'data-parser.test.js'),
-    path.join(__dirname, 'applescript-schedule.test.js')
+    path.join(__dirname, 'applescript-schedule.test.js'),
+    path.join(__dirname, 'tags-handling.test.js')
   ];
   
   let passed = 0;

--- a/test/tags-handling.test.js
+++ b/test/tags-handling.test.js
@@ -1,0 +1,181 @@
+/**
+ * Test for tags handling including empty array scenarios
+ */
+
+import { strict as assert } from 'assert';
+import { ParameterMapper, ParameterBuilder, AppleScriptSanitizer } from '../server/utils.js';
+import { AppleScriptTemplates } from '../server/applescript-templates.js';
+
+console.log('Testing tags handling functionality...\n');
+
+// Test 1: updateTodo with empty tags array removes all tags
+try {
+  const args = {
+    id: "test-todo-123",
+    tags: []
+  };
+  
+  const scriptParams = ParameterMapper.validateAndMapParameters(args);
+  const scriptTemplate = AppleScriptTemplates.updateTodo(scriptParams);
+  const buildParams = ParameterBuilder.buildParameters(
+    scriptParams, 
+    scriptParams.tags, 
+    scriptParams.due_date, 
+    scriptParams.activation_date
+  );
+  const script = AppleScriptSanitizer.buildScript(scriptTemplate, buildParams);
+  
+  // Should contain the command to set tags to empty
+  assert(script.includes('set tag names of targetTodo to {}'));
+  // Should be within a try block
+  assert(script.includes('try\n          set tag names of targetTodo to {}'));
+  
+  console.log('✅ updateTodo with empty tags array removes all tags');
+} catch (error) {
+  console.log('❌ updateTodo empty tags:', error.message);
+  process.exit(1);
+}
+
+// Test 2: updateTodo with non-empty tags array sets tags
+try {
+  const args = {
+    id: "test-todo-123",
+    tags: ["work", "urgent"]
+  };
+  
+  const scriptParams = ParameterMapper.validateAndMapParameters(args);
+  const scriptTemplate = AppleScriptTemplates.updateTodo(scriptParams);
+  const buildParams = ParameterBuilder.buildParameters(
+    scriptParams, 
+    scriptParams.tags, 
+    scriptParams.due_date, 
+    scriptParams.activation_date
+  );
+  const script = AppleScriptSanitizer.buildScript(scriptTemplate, buildParams);
+  
+  // Should contain the command to set tags
+  assert(script.includes('set tag names of targetTodo to {"work", "urgent"}'));
+  
+  console.log('✅ updateTodo with non-empty tags array sets tags');
+} catch (error) {
+  console.log('❌ updateTodo non-empty tags:', error.message);
+  process.exit(1);
+}
+
+// Test 3: updateProject with empty tags array removes all tags
+try {
+  const args = {
+    id: "test-project-456",
+    tags: []
+  };
+  
+  const scriptParams = ParameterMapper.validateAndMapParameters(args);
+  const scriptTemplate = AppleScriptTemplates.updateProject(scriptParams);
+  const buildParams = ParameterBuilder.buildParameters(
+    scriptParams, 
+    scriptParams.tags, 
+    scriptParams.due_date, 
+    scriptParams.activation_date
+  );
+  const script = AppleScriptSanitizer.buildScript(scriptTemplate, buildParams);
+  
+  // Should contain the command to set tags to empty
+  assert(script.includes('set tag names of targetProject to {}'));
+  // Should be within a try block
+  assert(script.includes('try\n          set tag names of targetProject to {}'));
+  
+  console.log('✅ updateProject with empty tags array removes all tags');
+} catch (error) {
+  console.log('❌ updateProject empty tags:', error.message);
+  process.exit(1);
+}
+
+// Test 4: updateProject with non-empty tags array sets tags
+try {
+  const args = {
+    id: "test-project-456",
+    tags: ["milestone", "q1"]
+  };
+  
+  const scriptParams = ParameterMapper.validateAndMapParameters(args);
+  const scriptTemplate = AppleScriptTemplates.updateProject(scriptParams);
+  const buildParams = ParameterBuilder.buildParameters(
+    scriptParams, 
+    scriptParams.tags, 
+    scriptParams.due_date, 
+    scriptParams.activation_date
+  );
+  const script = AppleScriptSanitizer.buildScript(scriptTemplate, buildParams);
+  
+  // Should contain the command to set tags
+  assert(script.includes('set tag names of targetProject to {"milestone", "q1"}'));
+  
+  console.log('✅ updateProject with non-empty tags array sets tags');
+} catch (error) {
+  console.log('❌ updateProject non-empty tags:', error.message);
+  process.exit(1);
+}
+
+// Test 5: updateTodo without tags parameter doesn't modify tags
+try {
+  const args = {
+    id: "test-todo-123",
+    title: "Updated title"
+  };
+  
+  const scriptParams = ParameterMapper.validateAndMapParameters(args);
+  const scriptTemplate = AppleScriptTemplates.updateTodo(scriptParams);
+  const buildParams = ParameterBuilder.buildParameters(
+    scriptParams, 
+    scriptParams.tags, 
+    scriptParams.due_date, 
+    scriptParams.activation_date
+  );
+  const script = AppleScriptSanitizer.buildScript(scriptTemplate, buildParams);
+  
+  // Should not contain any tag-related commands
+  assert(!script.includes('tag names'));
+  
+  console.log('✅ updateTodo without tags parameter doesn\'t modify tags');
+} catch (error) {
+  console.log('❌ updateTodo no tags parameter:', error.message);
+  process.exit(1);
+}
+
+// Test 6: Invalid tags parameter (non-array) throws error
+try {
+  const scriptParams = {
+    id: "test-todo-123",
+    tags: "not-an-array"  // This should cause an error
+  };
+  
+  // This should throw an error
+  const scriptTemplate = AppleScriptTemplates.updateTodo(scriptParams);
+  
+  console.log('❌ updateTodo should throw error for non-array tags');
+  process.exit(1);
+} catch (error) {
+  assert(error.message === 'tags parameter must be an array');
+  console.log('✅ updateTodo throws error for non-array tags parameter');
+}
+
+// Test 7: Null tags parameter is handled correctly
+try {
+  const scriptParams = {
+    id: "test-todo-123",
+    title: "Updated title",
+    tags: null
+  };
+  
+  const scriptTemplate = AppleScriptTemplates.updateTodo(scriptParams);
+  
+  // Should not contain any tag-related commands when tags is null
+  assert(!scriptTemplate.includes('tag names'));
+  
+  console.log('✅ updateTodo handles null tags parameter correctly');
+} catch (error) {
+  console.log('❌ updateTodo null tags parameter:', error.message);
+  process.exit(1);
+}
+
+console.log('\n✨ All tags handling tests passed!');


### PR DESCRIPTION
## Summary
- Fixes tag removal in `update_todo` and `update_project` when `tags: []` is provided
- Changes condition from `if (tags && tags.length > 0)` to `if (tags \!== undefined)`
- Handles both non-empty arrays (sets tags) and empty arrays (removes all tags)

## Problem
When calling `update_todo` or `update_project` with `tags: []`, the existing condition would skip the tag update entirely, leaving the current tags unchanged. This prevented users from removing all tags from an item.

## Solution
Modified the tag handling logic in both `updateTodo()` and `updateProject()` methods in `server/applescript-templates.js`:
- Check `if (tags \!== undefined)` to detect when tags parameter is provided
- For non-empty arrays: Set tag names to the specified tags (existing behavior)
- For empty arrays: Generate `set tag names of target to {}` which removes all tags

## Test plan
- [x] All existing tests pass
- [x] Manually tested with Things 3:
  - Create todo with tags
  - Call `update_todo` with `tags: []`
  - Verify all tags are removed

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)