### PR TITLE
fix: Enable todo creation when using add_project with todos array

### DIFF
--- a/server/applescript-templates.js
+++ b/server/applescript-templates.js
@@ -87,7 +87,7 @@ export class AppleScriptTemplates {
   /**
    * Create a new project
    */
-  static createProject({ name, notes, area, due_date, activation_date, tags }) {
+  static createProject({ name, notes, area, due_date, activation_date, tags, todos }) {
     let script = `tell application "Things3"
       set newProject to make new project with properties {name: "{{name}}"`;
     
@@ -132,6 +132,20 @@ export class AppleScriptTemplates {
       on error
         -- Scheduling failed, continue without scheduling
       end try`;
+    }
+    
+    // Create todos if provided
+    if (todos && todos.length > 0) {
+      script += `
+      -- Create todos for the project`;
+      todos.forEach((_, index) => {
+        script += `
+      try
+        make new to do with properties {name: "{{todo_${index}}}", project: newProject}
+      on error
+        -- Failed to create todo, continue with others
+      end try`;
+      });
     }
     
     script += `

--- a/server/utils.js
+++ b/server/utils.js
@@ -273,6 +273,13 @@ export class ParameterBuilder {
       });
     }
     
+    // Add individual todo parameters
+    if (baseParams.todos && Array.isArray(baseParams.todos)) {
+      baseParams.todos.forEach((todo, index) => {
+        buildParams[`todo_${index}`] = todo;
+      });
+    }
+    
     // Add formatted due date parameter
     if (dueDate) {
       try {

--- a/test/project-todos.test.js
+++ b/test/project-todos.test.js
@@ -1,0 +1,79 @@
+/**
+ * Test for project todos functionality
+ */
+
+import { strict as assert } from 'assert';
+import { AppleScriptTemplates } from '../server/applescript-templates.js';
+import { ParameterBuilder } from '../server/utils.js';
+
+console.log("Testing project todos functionality...\n");
+
+function testCreateProjectWithTodos() {
+  console.log("✅ createProject generates todos correctly");
+  
+  const params = {
+    name: "Road Trip Todo List",
+    notes: "Complete all tasks before the road trip",
+    todos: ["Pack snacks", "Get gas", "Check tires"]
+  };
+  
+  // Build parameters with todos
+  const buildParams = ParameterBuilder.buildParameters(params, null, null, null);
+  
+  // Verify todo parameters are created
+  assert.equal(buildParams.todo_0, "Pack snacks");
+  assert.equal(buildParams.todo_1, "Get gas");
+  assert.equal(buildParams.todo_2, "Check tires");
+  
+  // Generate the AppleScript
+  const script = AppleScriptTemplates.createProject(params);
+  
+  // Verify the script contains todo creation commands
+  assert(script.includes('make new to do with properties {name: "{{todo_0}}", project: newProject}'));
+  assert(script.includes('make new to do with properties {name: "{{todo_1}}", project: newProject}'));
+  assert(script.includes('make new to do with properties {name: "{{todo_2}}", project: newProject}'));
+  assert(script.includes('-- Create todos for the project'));
+}
+
+function testCreateProjectWithoutTodos() {
+  console.log("✅ createProject works without todos parameter");
+  
+  const params = {
+    name: "Simple Project",
+    notes: "A project without todos"
+  };
+  
+  const script = AppleScriptTemplates.createProject(params);
+  
+  // Verify the script doesn't contain todo creation commands
+  assert(!script.includes('-- Create todos for the project'));
+  assert(!script.includes('make new to do'));
+}
+
+function testCreateProjectWithEmptyTodos() {
+  console.log("✅ createProject handles empty todos array");
+  
+  const params = {
+    name: "Project with Empty Todos",
+    todos: []
+  };
+  
+  const script = AppleScriptTemplates.createProject(params);
+  
+  // Verify the script doesn't contain todo creation commands for empty array
+  assert(!script.includes('-- Create todos for the project'));
+  assert(!script.includes('make new to do'));
+}
+
+// Run tests
+try {
+  testCreateProjectWithTodos();
+  testCreateProjectWithoutTodos();
+  testCreateProjectWithEmptyTodos();
+  
+  console.log("\n✨ All project todos tests passed!");
+} catch (error) {
+  console.error("\n❌ Test failed:", error.message);
+  console.error(error.stack);
+  process.exit(1);
+}

--- a/test/run-tests.js
+++ b/test/run-tests.js
@@ -43,7 +43,8 @@ async function main() {
     path.join(__dirname, 'parameter-mapping.test.js'),
     path.join(__dirname, 'data-parser.test.js'),
     path.join(__dirname, 'applescript-schedule.test.js'),
-    path.join(__dirname, 'tags-handling.test.js')
+    path.join(__dirname, 'tags-handling.test.js'),
+    path.join(__dirname, 'project-todos.test.js')
   ];
   
   let passed = 0;


### PR DESCRIPTION
## Summary
- Fixes #5 - The `add_project` tool now properly creates todos when a `todos` array is provided
- Todos are created and automatically assigned to the newly created project

## Test plan
- Added comprehensive unit tests for the new functionality in `test/project-todos.test.js`
- All existing tests continue to pass
- Validated syntax with `npm run validate`

## Changes
- Updated `AppleScriptTemplates.createProject` to handle todos parameter and generate AppleScript to create todos
- Modified `ParameterBuilder.buildParameters` to map todo array items to individual parameters
- Added test coverage for:
  - Creating a project with todos
  - Creating a project without todos parameter
  - Creating a project with empty todos array

🤖 Generated with [Claude Code](https://claude.ai/code)